### PR TITLE
Remove newlines confusing Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,3 @@
-# This file was generated automatically from conda-smithy. To update this configuration,
-# update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
-
 ---
 # This pipeline is used to test various build configurations
 kind: pipeline


### PR DESCRIPTION
I saw your builds coming through today and since Ed reached out to me, I wanted to make sure I was helping you through any difficulties. I noticed they were failing with a strange empty step. It turns out our yaml parser doesn't like the newlines at the top, which interprets as a separate yaml document. I created an issue in our tracker to resolve, but in the meantime, you can resolve by starting the file with `---` in the first line.